### PR TITLE
Update GH page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ This is also a coursework project which will be submitted for grading in Level 4
 
 **Link to our GitHub Page**
 
-🔗[FeatherCSS]() (to be updated)
+🔗[FeatherCSS](https://le000255.github.io/feather-css/)

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -180,7 +180,7 @@ Here are some examples of using the utilities provided by this project:
   ```
 
 > [!Note]  
-> _For more details of how to use FeatherCSS, please visit our [GitHub page]() (to be updated)._
+> _For more details of how to use FeatherCSS, please visit our [GitHub page](https://le000255.github.io/feather-css/)._
 
 ### Customization
 


### PR DESCRIPTION
This pull request includes updates to documentation links to ensure they point to the correct GitHub page for FeatherCSS.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22): Updated the GitHub page link for FeatherCSS to `https://le000255.github.io/feather-css/`.
* [`docs/dev-guide.md`](diffhunk://#diff-fbdffcced43ae51406a84b80596bf79e8fdb08853cabe5cc17806f049791ba50L183-R183): Updated the GitHub page link for FeatherCSS in the note section to `https://le000255.github.io/feather-css/`.